### PR TITLE
Don't pass common options to unsquashfs

### DIFF
--- a/DeComp/definitions.py
+++ b/DeComp/definitions.py
@@ -376,7 +376,7 @@ DECOMPRESS_DEFINITIONS = {
     "squashfs": [
                     "_common", "unsquashfs",
                     [
-                        "other_options", "-d", "%(destination)s",
+                        "-d", "%(destination)s",
                         "%(basedir)s/%(source)s"
                     ],
                     "SQUASHFS", ["squashfs", "sfs"], {"unsquashfs"},


### PR DESCRIPTION
On Linux, other_options includes xattr extraction flags, however unsquashfs cannot handle these and exits without extracting files.

Fixes #3.