### PR TITLE
support squashfs* properly

### DIFF
--- a/DeComp/compress.py
+++ b/DeComp/compress.py
@@ -417,9 +417,10 @@ class CompressMap(object):
                 self.extension(cmdinfo["mode"])
 
         sqfs_opts = self._sub_other_options(cmdlist.args, cmdinfo)
-        if not infodict['arch']:
-            sqfs_opts.remove("-Xbcj")
-            sqfs_opts.remove("%(arch)s")
+        if infodict['mode'] == "squashfs_xz":
+	        if not infodict['arch']:
+                    sqfs_opts.remove("-Xbcj")
+                    sqfs_opts.remove("%(arch)s")
         opts = ' '.join(sqfs_opts) % (cmdinfo)
         args = ' '.join([cmdlist.cmd, opts])
 

--- a/DeComp/definitions.py
+++ b/DeComp/definitions.py
@@ -226,6 +226,14 @@ COMPRESS_DEFINITIONS = {
                 ],
                 "GZIP", ["tar.gz"], {"tar"},
               ],
+    "squashfs_zstd": [
+                    "_sqfs", "mksquashfs",
+                    [
+                        "%(basedir)s/%(source)s", "%(filename)s", "-comp", "zstd",
+                        "-Xcompression-level", "19", "-b", "1M", "-no-recovery", "-noappend", "other_options"
+                    ],
+                    "SQUASHFS", ["squashfs", "sfs"], {"mksquashfs"},
+                ],
     "squashfs_xz": [
                     "_sqfs", "mksquashfs",
                     [
@@ -376,8 +384,8 @@ DECOMPRESS_DEFINITIONS = {
     "squashfs": [
                     "_common", "unsquashfs",
                     [
-                        "other_options", "-d", "%(destination)s",
-                        "%(basedir)s/%(source)s"
+                        "other_options", "-f", "-d", "%(destination)s",
+                        "%(source)s"
                     ],
                     "SQUASHFS", ["squashfs", "sfs"], {"unsquashfs"},
                 ],


### PR DESCRIPTION
More or less this adds squashfs_zstd support and fixes the squashfs types to actually work for compression.

This now works as expected for squashfs_zstd.  It should decompress any squashfs* options, I haven't tested compressing them all yet.

New catalyst doesn't use pydecomp for compressing snapshots, but this does work properly with stages.