### PR TITLE
pixz trailing tarball index

### DIFF
--- a/DeComp/definitions.py
+++ b/DeComp/definitions.py
@@ -200,6 +200,14 @@ COMPRESS_DEFINITIONS = {
                 ],
                 "PIXZ", ["tar.xz", "tpxz", "xz"], {"tar", "pixz"},
             ],
+    "pixz_i": [
+                "_common", "tar",
+                [
+                    "other_options", "%(comp_prog)s", "pixz", "-cpf",
+                    "%(filename)s", "-C", "%(basedir)s", "%(source)s"
+                ],
+                "PIXZ", ["tar.xz", "tpxz", "xz"], {"tar", "pixz"},
+            ],
     "pixz_x": [
                 "_common", "tar",
                 [

--- a/DeComp/definitions.py
+++ b/DeComp/definitions.py
@@ -195,7 +195,7 @@ COMPRESS_DEFINITIONS = {
     "pixz": [
                 "_common", "tar",
                 [
-                    "other_options", "%(comp_prog)s", "pixz", "-cpf",
+                    "other_options", "%(comp_prog)s", "'pixz -t'", "-cpf",
                     "%(filename)s", "-C", "%(basedir)s", "%(source)s"
                 ],
                 "PIXZ", ["tar.xz", "tpxz", "xz"], {"tar", "pixz"},


### PR DESCRIPTION
If pixz detects the input file is a tarball, it adds a trailing file index to help in seeking the file. However, this trailing index is causes decompression errors with xz -d and systemd-importd.

For compatibility with these tools, force pixz to never add this tarball index.

If trailing file indexes are desired, a copy of the original "pixz" compressor is available at "pixz_i" (for indexed).

Resolves https://bugs.gentoo.org/787194